### PR TITLE
chore(shared): relax module resolution for ts imports

### DIFF
--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -9,8 +9,8 @@
     "noEmit": false,
     "outDir": "dist",
     "sourceMap": true,
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
   },
   "include": [
     "enums/**/*.ts",

--- a/packages/shared/types/apiFigurantClient.ts
+++ b/packages/shared/types/apiFigurantClient.ts
@@ -1,6 +1,6 @@
-import { Language } from '../enums/Language.js';
-import { Personality, Profile, Scenario } from './supabase/supabaseTypeHelpers.js';
-import { ChatMessage } from './chatMessage.js';
+import { Language } from '../enums/Language';
+import { Personality, Profile, Scenario } from './supabase/supabaseTypeHelpers';
+import { ChatMessage } from './chatMessage';
 
 export interface TextToSpeechRequest {
     inputMessage: string;

--- a/packages/shared/types/apiKeyStatus.ts
+++ b/packages/shared/types/apiKeyStatus.ts
@@ -1,4 +1,4 @@
-import { ApiKey } from '../enums/ApiKey.js';
+import { ApiKey } from '../enums/ApiKey';
 
 export interface AiProviderStatus {
     apiKey: ApiKey;

--- a/packages/shared/types/conversationLog.ts
+++ b/packages/shared/types/conversationLog.ts
@@ -1,4 +1,4 @@
-import { Json } from './supabase/database.types.js';
+import { Json } from './supabase/database.types';
 
 export interface ConversationLog {
     timestamp: string;

--- a/packages/shared/types/modelSelection.ts
+++ b/packages/shared/types/modelSelection.ts
@@ -4,8 +4,8 @@ import {
   ResponseModel,
   TimestampedTranscriptionModel,
   TtsModel,
-} from './supabase/supabaseTypeHelpers.js';
-import { WithAvailability } from '../utils/filterModelsByApiKeyStatus.js';
+} from './supabase/supabaseTypeHelpers';
+import { WithAvailability } from '../utils/filterModelsByApiKeyStatus';
 
 export interface ModelOptions {
     responseModels: ResponseModel[];

--- a/packages/shared/types/myConversation.ts
+++ b/packages/shared/types/myConversation.ts
@@ -1,4 +1,4 @@
-import { ChatMessage } from './chatMessage.js';
+import { ChatMessage } from './chatMessage';
 
 export interface MyConversation {
     id: number;

--- a/packages/shared/types/supabase/supabaseTypeHelpers.ts
+++ b/packages/shared/types/supabase/supabaseTypeHelpers.ts
@@ -1,4 +1,4 @@
-import { Enums, Tables, TablesInsert } from './database.types.js';
+import { Enums, Tables, TablesInsert } from './database.types';
 
 export type Profile = Tables<'profiles'>;
 export type UserRole = Enums<'user_role'>;

--- a/packages/shared/utils/access.ts
+++ b/packages/shared/utils/access.ts
@@ -1,4 +1,4 @@
-import { Profile } from '../types/supabase/supabaseTypeHelpers.js';
+import { Profile } from '../types/supabase/supabaseTypeHelpers';
 
 export const isProfileAdmin = (profile: Profile) => {
   return profile.user_role === 'admin' || profile.user_role === 'owner';

--- a/packages/shared/utils/createPersonalityPrompt.ts
+++ b/packages/shared/utils/createPersonalityPrompt.ts
@@ -1,5 +1,5 @@
-import { Language } from '../enums/Language.js';
-import { Personality, Profile, Scenario } from '../types/supabase/supabaseTypeHelpers.js';
+import { Language } from '../enums/Language';
+import { Personality, Profile, Scenario } from '../types/supabase/supabaseTypeHelpers';
 
 interface GetPersonalityPromptParams {
     personality: Personality;

--- a/packages/shared/utils/customConversationOptions.ts
+++ b/packages/shared/utils/customConversationOptions.ts
@@ -1,5 +1,5 @@
-import { ConversationRole, Personality, Scenario } from '../types/supabase/supabaseTypeHelpers.js';
-import { LANGUAGE, Language } from '../enums/Language.js';
+import { ConversationRole, Personality, Scenario } from '../types/supabase/supabaseTypeHelpers';
+import { LANGUAGE, Language } from '../enums/Language';
 
 export type PersonalityTabKey = 'predefined' | 'custom';
 export type ScenarioTabKey = 'none' | 'predefined' | 'custom';

--- a/packages/shared/utils/filterModelsByApiKeyStatus.ts
+++ b/packages/shared/utils/filterModelsByApiKeyStatus.ts
@@ -1,13 +1,13 @@
-import { AiProviderStatus } from '../types/apiKeyStatus.js';
-import { API_KEY, ApiKey } from '../enums/ApiKey.js';
-import { Enums } from '../types/supabase/database.types.js';
+import { AiProviderStatus } from '../types/apiKeyStatus';
+import { API_KEY, ApiKey } from '../enums/ApiKey';
+import { Enums } from '../types/supabase/database.types';
 import type {
   RealtimeModel,
   RealtimeTranscriptionModel,
   ResponseModel,
   TimestampedTranscriptionModel,
   TtsModel,
-} from '../types/supabase/supabaseTypeHelpers.js';
+} from '../types/supabase/supabaseTypeHelpers';
 
 export const realtimeProvidersApiKeys = {
   'OpenAi': API_KEY.OPENAI,

--- a/packages/shared/utils/universalDescriptionMoreLanguages.ts
+++ b/packages/shared/utils/universalDescriptionMoreLanguages.ts
@@ -1,5 +1,5 @@
-import { LANGUAGE, Language } from '../enums/Language.js';
-import { Personality, Scenario } from '../types/supabase/supabaseTypeHelpers.js';
+import { LANGUAGE, Language } from '../enums/Language';
+import { Personality, Scenario } from '../types/supabase/supabaseTypeHelpers';
 
 export const universalDescriptionForScenario = (s: Scenario, lang: Language): {
     situationDescription: string;


### PR DESCRIPTION
## Summary
- switch the shared package to ESNext/Bundler module settings so TypeScript no longer requires explicit .js suffixes
- drop the .js suffix from internal shared package imports now that the compiler resolves them automatically

## Testing
- pnpm build (from packages/shared)


------
https://chatgpt.com/codex/tasks/task_e_68d5de64b3248327ba394568f09fd507